### PR TITLE
Update mingw

### DIFF
--- a/build_wxPack.bat
+++ b/build_wxPack.bat
@@ -75,9 +75,9 @@ goto BUILD_WXCOMPILED
 	if ERRORLEVEL 1 goto ERROR
 	call wxBuild_wxWidgets.bat VC140_64 ALL
 	if ERRORLEVEL 1 goto ERROR
-	::call wxBuild_wxWidgets.bat MINGW4_W64 ALL
+	::call wxBuild_wxWidgets.bat MINGW_W64 ALL
 	::if ERRORLEVEL 1 goto ERROR
-	::call wxBuild_wxWidgets.bat MINGW4_W64_64 ALL
+	::call wxBuild_wxWidgets.bat MINGW_W64_64 ALL
 	::if ERRORLEVEL 1 goto ERROR
 
 	echo Change to installer directory

--- a/build_wxPack.bat
+++ b/build_wxPack.bat
@@ -22,23 +22,23 @@ goto CONFIGURE
 	copy wx_no_3rd_party.bkl /Y wxwidgets\build\bakefiles
 
 	::echo Create directories for binary targets in GCC because of a bug in the wx Makefiles.
-	::mkdir wxwidgets\lib\gcc48_dll\msw\wx
-	::mkdir wxwidgets\lib\gcc48_dll\mswd\wx
-	::mkdir wxwidgets\lib\gcc48_dll\mswu\wx
-	::mkdir wxwidgets\lib\gcc48_dll\mswud\wx
-	::mkdir wxwidgets\lib\gcc48_lib\msw\wx
-	::mkdir wxwidgets\lib\gcc48_lib\mswd\wx
-	::mkdir wxwidgets\lib\gcc48_lib\mswu\wx
-	::mkdir wxwidgets\lib\gcc48_lib\mswud\wx
+	::mkdir wxwidgets\lib\gcc81_dll\msw\wx
+	::mkdir wxwidgets\lib\gcc81_dll\mswd\wx
+	::mkdir wxwidgets\lib\gcc81_dll\mswu\wx
+	::mkdir wxwidgets\lib\gcc81_dll\mswud\wx
+	::mkdir wxwidgets\lib\gcc81_lib\msw\wx
+	::mkdir wxwidgets\lib\gcc81_lib\mswd\wx
+	::mkdir wxwidgets\lib\gcc81_lib\mswu\wx
+	::mkdir wxwidgets\lib\gcc81_lib\mswud\wx
 	
-	::mkdir wxwidgets\lib\gcc48_dll_x64\msw\wx
-	::mkdir wxwidgets\lib\gcc48_dll_x64\mswd\wx
-	::mkdir wxwidgets\lib\gcc48_dll_x64\mswu\wx
-	::mkdir wxwidgets\lib\gcc48_dll_x64\mswud\wx
-	::mkdir wxwidgets\lib\gcc48_lib_x64\msw\wx
-	::mkdir wxwidgets\lib\gcc48_lib_x64\mswd\wx
-	::mkdir wxwidgets\lib\gcc48_lib_x64\mswu\wx
-	::mkdir wxwidgets\lib\gcc48_lib_x64\mswud\wx
+	::mkdir wxwidgets\lib\gcc81_dll_x64\msw\wx
+	::mkdir wxwidgets\lib\gcc81_dll_x64\mswd\wx
+	::mkdir wxwidgets\lib\gcc81_dll_x64\mswu\wx
+	::mkdir wxwidgets\lib\gcc81_dll_x64\mswud\wx
+	::mkdir wxwidgets\lib\gcc81_lib_x64\msw\wx
+	::mkdir wxwidgets\lib\gcc81_lib_x64\mswd\wx
+	::mkdir wxwidgets\lib\gcc81_lib_x64\mswu\wx
+	::mkdir wxwidgets\lib\gcc81_lib_x64\mswud\wx
 
 	set INNOSETUPPATH=
 	if exist "%ProgramFiles%\Inno Setup 5\iscc.exe" set INNOSETUPPATH="%ProgramFiles%\Inno Setup 5\iscc.exe"
@@ -98,7 +98,7 @@ goto BUILD_WXPACK
 	echo Starting to build wxFormBuilder from '%CD%'
 
 	:: MinGW Gcc install location. This must match you systems configuration.
-	set GCCDIR=C:\GCC\MinGW-w64\4.8.1
+	set GCCDIR=C:\Program Files (x86)\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32
 	set CC=gcc
 	set CXX=g++
 
@@ -119,11 +119,11 @@ goto BUILD_WXPACK
 	git submodule update
 
 	echo Copying over wxWidgets dlls from %WXWIN%
-	copy %WXWIN%\lib\gcc48_dll\wxmsw30u_gcc48.dll /Y output\
+	copy %WXWIN%\lib\gcc81_dll\wxmsw30u_gcc81.dll /Y output\
 	echo Copying over MinGW dlls
 
 	echo Create the build files.
-	call create_build_files4.bat --wx-version=3.0 --compiler=mingw64 --compiler-version=48
+	call create_build_files4.bat --wx-version=3.0 --compiler=mingw64 --compiler-version=81
 	if ERRORLEVEL 1 goto ERROR
 
 	echo Change to build directory.

--- a/wxBuild_wxWidgets.bat
+++ b/wxBuild_wxWidgets.bat
@@ -46,6 +46,7 @@ set MINGW_W64_64_DIR=C:\GCC\MinGW-w64\4.8.1
 set MINGW_W64_64_VER=48
 
 set CPU=X86
+set CFG=
 
 if (%1) == () goto ERROR
 :: -- Check if user wants help --
@@ -796,10 +797,26 @@ goto END
 set WXBUILD_VERSION=
 set WXBUILD_APPNAME=
 set GCCDIR=
+set GCCVER=
 set GCC4DIR=
+set GCC4VER=
+set MINGW_W64_DIR=
+set MINGW_W64_VER=
+set MINGW_W64_64_DIR=
+set MINGW_W64_64_VER=
+set CPU=
+set CFG=
+set HOSTARCH=
+set CMD32=
+set CMD64=
+set BASEDIR=
+set INSTALLDIR=
 set MAKE=
 set MAKEFILE=
 set FLAGS=
-set CPU=
-set COMPILER_FLAGS=
+set COMPILER_VERSION=
+set COMPILER_NAME=
+set COMPILER_ARCH=
+set BAKE_FORMAT=
+set BAKE_OPTIONS_FILE=
 ENDLOCAL

--- a/wxBuild_wxWidgets.bat
+++ b/wxBuild_wxWidgets.bat
@@ -41,6 +41,9 @@ set GCC4VER=48
 :: MinGW-w64 Gcc install location. This must match your systems configuration.
 set MINGW_W64_DIR=C:\GCC\MinGW-w64\4.8.1
 set MINGW_W64_VER=48
+:: MinGW-w64 x64 Gcc install location. This must match your systems configuration.
+set MINGW_W64_64_DIR=C:\GCC\MinGW-w64\4.8.1
+set MINGW_W64_64_VER=48
 
 set CPU=X86
 
@@ -549,19 +552,19 @@ goto START
 
 :SETUP_MINGW_W64_64_BUILD_ENVIRONMENT
 echo Assuming that MinGW-w64 has been installed to:
-echo   %MINGW_W64_DIR%
+echo   %MINGW_W64_64_DIR%
 echo.
 :: -- Add MinGW directory to the systems PATH --
 echo Setting environment for MinGW4-w64 64-bit Gcc...
-if "%OS%" == "Windows_NT" set PATH=%MINGW_W64_DIR%\BIN;%PATH%
-if "%OS%" == "" set PATH="%MINGW_W64_DIR%\BIN";"%PATH%"
+if "%OS%" == "Windows_NT" set PATH=%MINGW_W64_64_DIR%\BIN;%PATH%
+if "%OS%" == "" set PATH="%MINGW_W64_64_DIR%\BIN";"%PATH%"
 echo.
 :: -- Setup the make executable and the actual makefile name --
 set CFG=_x64
 set MAKE=mingw32-make.exe
 set MAKEFILE=makefile.gcc
 set FLAGS=CXXFLAGS=-Wno-attributes USE_ODBC=1 USE_OPENGL=1 USE_QA=1 USE_GDIPLUS=0 -j %NUMBER_OF_PROCESSORS%
-set COMPILER_VERSION=%MINGW_W64_VER%
+set COMPILER_VERSION=%MINGW_W64_64_VER%
 set COMPILER_NAME=mingw
 set COMPILER_ARCH=64
 set BAKE_FORMAT=mingw

--- a/wxBuild_wxWidgets.bat
+++ b/wxBuild_wxWidgets.bat
@@ -39,11 +39,11 @@ set GCCVER=3
 set GCC4DIR=C:\MinGW4
 set GCC4VER=48
 :: MinGW-w64 Gcc install location. This must match your systems configuration.
-set MINGW_W64_DIR=C:\GCC\MinGW-w64\4.8.1
-set MINGW_W64_VER=48
+set MINGW_W64_DIR=C:\Program Files (x86)\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32
+set MINGW_W64_VER=81
 :: MinGW-w64 x64 Gcc install location. This must match your systems configuration.
-set MINGW_W64_64_DIR=C:\GCC\MinGW-w64\4.8.1
-set MINGW_W64_64_VER=48
+set MINGW_W64_64_DIR=C:\Program Files\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64
+set MINGW_W64_64_VER=81
 
 set CPU=X86
 set CFG=

--- a/wxBuild_wxWidgets.bat
+++ b/wxBuild_wxWidgets.bat
@@ -38,9 +38,9 @@ set GCCVER=3
 :: MinGW4 Gcc install location. This must match your systems configuration.
 set GCC4DIR=C:\MinGW4
 set GCC4VER=48
-:: MinGW4-w64 Gcc install location. This must match your systems configuration.
-set MINGW4_W64_DIR=C:\GCC\MinGW-w64\4.8.1
-set MINGW4_W64_GCC4VER=48
+:: MinGW-w64 Gcc install location. This must match your systems configuration.
+set MINGW_W64_DIR=C:\GCC\MinGW-w64\4.8.1
+set MINGW_W64_VER=48
 
 set CPU=X86
 
@@ -93,10 +93,10 @@ if %1 == MINGW          goto SETUP_GCC_BUILD_ENVIRONMENT
 if %1 == mingw          goto SETUP_GCC_BUILD_ENVIRONMENT
 if %1 == MINGW4         goto SETUP_GCC4_BUILD_ENVIRONMENT
 if %1 == mingw4         goto SETUP_GCC4_BUILD_ENVIRONMENT
-if %1 == MINGW4_W64     goto SETUP_MINGW4_W64_BUILD_ENVIRONMENT
-if %1 == mingw4_w64     goto SETUP_MINGW4_W64_BUILD_ENVIRONMENT
-if %1 == MINGW4_W64_64  goto SETUP_MINGW4_W64_64_BUILD_ENVIRONMENT
-if %1 == mingw4_w64_64  goto SETUP_MINGW4_W64_64_BUILD_ENVIRONMENT
+if %1 == MINGW_W64      goto SETUP_MINGW_W64_BUILD_ENVIRONMENT
+if %1 == mingw_w64      goto SETUP_MINGW_W64_BUILD_ENVIRONMENT
+if %1 == MINGW_W64_64   goto SETUP_MINGW_W64_64_BUILD_ENVIRONMENT
+if %1 == mingw_w64_64   goto SETUP_MINGW_W64_64_BUILD_ENVIRONMENT
 goto COMPILER_ERROR
 
 :SETUP_VC71_TOOLKIT_BUILD_ENVIRONMENT
@@ -527,41 +527,41 @@ set BAKE_FORMAT=mingw
 set BAKE_OPTIONS_FILE=config.gcc
 goto START
 
-:SETUP_MINGW4_W64_BUILD_ENVIRONMENT
+:SETUP_MINGW_W64_BUILD_ENVIRONMENT
 echo Assuming that MinGW-w64 has been installed to:
-echo   %MINGW4_W64_DIR%
+echo   %MINGW_W64_DIR%
 echo.
 :: -- Add MinGW directory to the systems PATH --
 echo Setting environment for MinGW4-w64 Gcc...
-if "%OS%" == "Windows_NT" set PATH=%MINGW4_W64_DIR%\BIN;%PATH%
-if "%OS%" == "" set PATH="%MINGW4_W64_DIR%\BIN";"%PATH%"
+if "%OS%" == "Windows_NT" set PATH=%MINGW_W64_DIR%\BIN;%PATH%
+if "%OS%" == "" set PATH="%MINGW_W64_DIR%\BIN";"%PATH%"
 echo.
 :: -- Setup the make executable and the actual makefile name --
 set MAKE=mingw32-make.exe
 set MAKEFILE=makefile.gcc
 set FLAGS=CXXFLAGS=-Wno-attributes USE_ODBC=1 USE_OPENGL=1 USE_QA=1 USE_GDIPLUS=0 -j %NUMBER_OF_PROCESSORS% CFLAGS=-m32 CPPFLAGS=-m32 LDFLAGS=-m32 CC="gcc -m32" WINDRES="windres --use-temp-file -F pe-i386"
-set COMPILER_VERSION=%MINGW4_W64_GCC4VER%
+set COMPILER_VERSION=%MINGW_W64_VER%
 set COMPILER_NAME=mingw
 set COMPILER_ARCH=32
 set BAKE_FORMAT=mingw
 set BAKE_OPTIONS_FILE=config.gcc
 goto START
 
-:SETUP_MINGW4_W64_64_BUILD_ENVIRONMENT
+:SETUP_MINGW_W64_64_BUILD_ENVIRONMENT
 echo Assuming that MinGW-w64 has been installed to:
-echo   %MINGW4_W64_DIR%
+echo   %MINGW_W64_DIR%
 echo.
 :: -- Add MinGW directory to the systems PATH --
 echo Setting environment for MinGW4-w64 64-bit Gcc...
-if "%OS%" == "Windows_NT" set PATH=%MINGW4_W64_DIR%\BIN;%PATH%
-if "%OS%" == "" set PATH="%MINGW4_W64_DIR%\BIN";"%PATH%"
+if "%OS%" == "Windows_NT" set PATH=%MINGW_W64_DIR%\BIN;%PATH%
+if "%OS%" == "" set PATH="%MINGW_W64_DIR%\BIN";"%PATH%"
 echo.
 :: -- Setup the make executable and the actual makefile name --
 set CFG=_x64
 set MAKE=mingw32-make.exe
 set MAKEFILE=makefile.gcc
 set FLAGS=CXXFLAGS=-Wno-attributes USE_ODBC=1 USE_OPENGL=1 USE_QA=1 USE_GDIPLUS=0 -j %NUMBER_OF_PROCESSORS%
-set COMPILER_VERSION=%MINGW4_W64_GCC4VER%
+set COMPILER_VERSION=%MINGW_W64_VER%
 set COMPILER_NAME=mingw
 set COMPILER_ARCH=64
 set BAKE_FORMAT=mingw
@@ -744,8 +744,8 @@ echo.
 echo      Compiler Options:
 echo           MINGW         = MinGW Gcc v3.x.x compiler
 echo           MINGW4        = MinGW Gcc v4.x.x compiler
-echo           MINGW4_W64    = MinGW-w64 Gcc v4.x.x compiler
-echo           MINGW4_W64_64 = MinGW-w64 Gcc v4.x.x compiler 64-bit
+echo           MINGW_W64     = MinGW-w64 Gcc compiler
+echo           MINGW_W64_64  = MinGW-w64 Gcc compiler 64-bit
 echo           VCTK          = Visual C++ 7.1 Toolkit
 echo           VC71          = Visual C++ 7.1
 echo           VC80          = Visual C++ 8.0


### PR DESCRIPTION
Update the MinGW-w64 parts to work better with the recent releases. Change the default values to match the default installation paths on a 64 bit OS and update the version to the latest.